### PR TITLE
DIAN-664

### DIFF
--- a/arc/src/main/java/edu/wustl/arc/core/ArcBaseFragment.java
+++ b/arc/src/main/java/edu/wustl/arc/core/ArcBaseFragment.java
@@ -25,9 +25,13 @@ package edu.wustl.arc.core;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
+
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import edu.wustl.arc.navigation.NavigationManager;
+import edu.wustl.arc.study.Study;
 import edu.wustl.arc.utilities.ViewUtil;
 
 import android.util.Log;
@@ -56,7 +60,23 @@ public class ArcBaseFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        getMainActivity().enableBackPress(backAllowed,backInStudy);
+        if (getActivity() instanceof ArcAssessmentActivity) {
+            getMainActivity().enableBackPress(backAllowed, backInStudy);
+        } else {
+            requireActivity().getOnBackPressedDispatcher().addCallback(
+                    new OnBackPressedCallback(!backAllowed) {
+                @Override
+                public void handleOnBackPressed() {
+                    if(backAllowed){
+                        if(Study.isValid() && backInStudy){
+                            Study.openPreviousFragment();
+                        } else {
+                            NavigationManager.getInstance().popBackStack();
+                        }
+                    }
+                }
+            });
+        }
     }
 
     public void allowBackPress(boolean inStudy){
@@ -81,7 +101,10 @@ public class ArcBaseFragment extends Fragment {
     // convenience methods for manipulating the keyboard -------------------------------------------
 
     public void hideKeyboard() {
-        Activity activity = getMainActivity();
+        if (getActivity() == null) {
+            return;
+        }
+        Activity activity = getActivity();
         InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
         //Find the currently focused view, so we can grab the correct window token from it.
         View view = activity.getCurrentFocus();
@@ -93,7 +116,10 @@ public class ArcBaseFragment extends Fragment {
     }
 
     public void showKeyboard(View view){
-        InputMethodManager imm = (InputMethodManager) getMainActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (getActivity() == null) {
+            return;
+        }
+        InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
     }
 
@@ -111,7 +137,7 @@ public class ArcBaseFragment extends Fragment {
             return null;
         }
 
-        Animation anim = AnimationUtils.loadAnimation(getMainActivity(), nextAnim);
+        Animation anim = AnimationUtils.loadAnimation(getActivity(), nextAnim);
         anim.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {

--- a/arc/src/main/java/edu/wustl/arc/core/SplashScreen.java
+++ b/arc/src/main/java/edu/wustl/arc/core/SplashScreen.java
@@ -79,7 +79,9 @@ public class SplashScreen extends ArcBaseFragment {
 
     private void initializeApp() {
         Context context = getContext();
-        getMainActivity().setupKeyboardWatcher();
+        if (getActivity() instanceof ArcAssessmentActivity) {
+            getMainActivity().setupKeyboardWatcher();
+        }
 
         ArcApplication.getInstance().updateLocale(getContext());
 
@@ -112,7 +114,9 @@ public class SplashScreen extends ArcBaseFragment {
 
         ready = true;
 
-        getMainActivity().getWindow().setBackgroundDrawableResource(R.drawable.core_background);
+        if (getActivity() != null) {
+            getActivity().getWindow().setBackgroundDrawableResource(R.drawable.core_background);
+        }
 
         if(!paused){
             exit();

--- a/arc/src/main/java/edu/wustl/arc/paths/questions/QuestionInteger.java
+++ b/arc/src/main/java/edu/wustl/arc/paths/questions/QuestionInteger.java
@@ -33,6 +33,7 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import edu.wustl.arc.core.ArcAssessmentActivity;
 import edu.wustl.arc.ui.IntegerInput;
 import edu.wustl.arc.paths.templates.QuestionTemplate;
 import edu.wustl.arc.utilities.KeyboardWatcher;
@@ -108,13 +109,17 @@ public class QuestionInteger extends QuestionTemplate {
             value = input.getString();
         }
         hideKeyboard();
-        getMainActivity().removeKeyboardListener();
+        if (getActivity() instanceof ArcAssessmentActivity) {
+            getMainActivity().removeKeyboardListener();
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
-        getMainActivity().setKeyboardListener(keyboardToggleListener);
+        if (getActivity() instanceof ArcAssessmentActivity) {
+            getMainActivity().setKeyboardListener(keyboardToggleListener);
+        }
 
     }
 

--- a/arc/src/main/java/edu/wustl/arc/paths/questions/QuestionRating.java
+++ b/arc/src/main/java/edu/wustl/arc/paths/questions/QuestionRating.java
@@ -97,7 +97,7 @@ public class QuestionRating extends QuestionTemplate {
         super.onEnterTransitionEnd(popped);
 
         if(!Hints.hasBeenShown(HINT_QUESTION_RATING)){
-            pointer = new HintPointer(getMainActivity(),rating.getSeekBar(),true,true);
+            pointer = new HintPointer(getActivity(),rating.getSeekBar(),true,true);
             pointer.setText(ViewUtil.getString(R.string.popup_drag));
             pointer.show();
             Hints.markShown(HINT_QUESTION_RATING);

--- a/arc/src/main/java/edu/wustl/arc/paths/questions/QuestionTime.java
+++ b/arc/src/main/java/edu/wustl/arc/paths/questions/QuestionTime.java
@@ -144,7 +144,7 @@ public class QuestionTime extends QuestionTemplate {
         }
 
         if(!Hints.hasBeenShown(HINT_QUESTION_TIME)){
-            pointer = new HintPointer(getMainActivity(),timeInput.getTimePicker(),true,false);
+            pointer = new HintPointer(getActivity(),timeInput.getTimePicker(),true,false);
             pointer.setText(ViewUtil.getString(R.string.popup_scroll));
             pointer.show();
         }

--- a/arc/src/main/java/edu/wustl/arc/paths/templates/TestInfoTemplate.java
+++ b/arc/src/main/java/edu/wustl/arc/paths/templates/TestInfoTemplate.java
@@ -190,7 +190,10 @@ public class TestInfoTemplate extends ArcBaseFragment {
         textViewTutorial.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                getMainActivity().getWindow().setBackgroundDrawableResource(R.color.secondary);
+                if (getActivity() == null) {
+                    return;
+                }
+                getActivity().getWindow().setBackgroundDrawableResource(R.color.secondary);
                 if(tutorialHint!=null) {
                     tutorialHint.dismiss();
                 }
@@ -240,10 +243,10 @@ public class TestInfoTemplate extends ArcBaseFragment {
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
-                if(getMainActivity()==null){
+                if(getActivity() == null){
                     return;
                 }
-                getMainActivity().getWindow().setBackgroundDrawableResource(R.drawable.core_background);
+                getActivity().getWindow().setBackgroundDrawableResource(R.drawable.core_background);
             }
             }, 1000);
     }

--- a/arc/src/main/java/edu/wustl/arc/paths/tests/Grid2Test.java
+++ b/arc/src/main/java/edu/wustl/arc/paths/tests/Grid2Test.java
@@ -112,7 +112,7 @@ public class Grid2Test extends ArcBaseFragment {
                 view.setSelected(true);
 
                 dialog = new Grid2ChoiceDialog(
-                        getMainActivity(),
+                        getActivity(),
                         view,
                         pointerPosition);
 


### PR DESCRIPTION
As a part of the ARC x MTB integration, I had to remove the dependency on the presenting Activity being ArcAssessmentActivity.  

The back button functionality I replaced with the new proper way to handle back presses, which does allow the fragment to control it.  

And with the keyboard listener, I made that optional as it is only applicable to Integer survey questions, which is not being ported over to MTB. 

The rest were just inappropriately relying on ArcAssessmentActivity when any activity would do.  Those have been replaced with getActivity() 