### PR TITLE
Set ArcAssessmentResultObject as the top-level result.

### DIFF
--- a/sage/src/main/java/edu/wustl/arc/sageassessments/ArcAssessmentFragment.kt
+++ b/sage/src/main/java/edu/wustl/arc/sageassessments/ArcAssessmentFragment.kt
@@ -40,7 +40,12 @@ class ArcAssessmentFragment: AssessmentFragment() {
         arcViewModel = ViewModelProvider(this)[ArcAssessmentViewModel::class.java]
         arcViewModel.arcResultLiveData.observe(viewLifecycleOwner) {
             if (it.isComplete) {
-                viewModel.assessmentNodeState.currentResult.inputResults.add(it)
+                (viewModel.assessmentNodeState.currentResult as ArcAssessmentResultObject).apply {
+                    startDateTime = it.startDateTime
+                    endDateTime = it.endDateTime
+                    isComplete = it.isComplete
+                    resultJsonStr = it.resultJsonStr
+                }
                 viewModel.goForward()
             }
         }

--- a/sage/src/main/res/raw/washu_arc_assessment_registry.json
+++ b/sage/src/main/res/raw/washu_arc_assessment_registry.json
@@ -5,6 +5,7 @@
       {
         "type": "arcAssessmentObject",
         "identifier": "symbol_test",
+        "arcAssessmentType": "symbol_test",
         "title": "Symbol Test",
         "steps": [
           {
@@ -17,6 +18,7 @@
       {
         "type": "arcAssessmentObject",
         "identifier": "price_test",
+        "arcAssessmentType": "price_test",
         "title": "Price Test",
         "steps": [
           {
@@ -29,6 +31,7 @@
       {
         "type": "arcAssessmentObject",
         "identifier": "grid_test",
+        "arcAssessmentType": "grid_test",
         "title": "Grid Test",
         "steps": [
           {


### PR DESCRIPTION
This will allow the archiver to include data.json file without also having a mostly empty assessmentResult.json.